### PR TITLE
2.3.8

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,14 @@
 
+2.3.8
+
+* Write out crosslinker stub information to mzIdentML
+* updated to XLMOD java library 1.1 to reduce "unknown modifications"
+* BugFix: mzIdentML 1.3 empty protein descriptions no longer written out
+* BugFix: mzIdentML 1.3 export still had some mzIdentML 1.2 namespace attributes
+   * currently using a modified version of jmzIdentML (pull request pending)
+   * allow matching to crosslinker without mass definition (e.g. DSSO)
+* BugFix: mzIdentML export for non-covalent peptide pairs
+
 2.3.7
 
 * BugFix: xiview csv file can miss data

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.rappsilberlab</groupId>
     <artifactId>xiFDR</artifactId>
-    <version>2.3.7</version>
+    <version>2.3.8</version>
     <packaging>jar</packaging>
     <dependencies>
         <dependency>
@@ -25,11 +25,6 @@
             <scope>runtime</scope>
             <type>jar</type>
         </dependency-->
-        <dependency>
-            <groupId>org.rappsilber</groupId>
-            <artifactId>XLMOD</artifactId>
-            <version>1.0</version>
-        </dependency>
         <dependency>
           <groupId>uk.ac.liv</groupId>
           <artifactId>mzidlib</artifactId>
@@ -105,14 +100,19 @@
             <version>1.1.1</version>
 	</dependency>
         <dependency>
-          <groupId>uk.ac.ebi.jmzidml</groupId>
-          <artifactId>jmzidentml</artifactId>
-          <version>1.2.13</version>
-        </dependency>
-        <dependency>
             <groupId>rappsilber</groupId>
             <artifactId>xiSEARCH</artifactId>
             <version>1.8.7</version>
+        </dependency>
+        <dependency>
+            <groupId>uk.ac.ebi.jmzidml</groupId>
+            <artifactId>jmzidentml</artifactId>
+            <version>1.2.13-lf</version>
+        </dependency>
+        <dependency>
+            <groupId>org.rappsilber</groupId>
+            <artifactId>XLMOD</artifactId>
+            <version>1.1</version>
         </dependency>
     </dependencies>
     <build>
@@ -170,5 +170,5 @@
         <maven.compiler.target>1.7</maven.compiler.target>
     </properties>
     <description>Application for FDR estimation cross-linking massspectrometry data </description>
-    <name>xiFDR-2.3.7</name>
+    <name>xiFDR-2.3.8</name>
 </project>

--- a/src/main/java/org/rappsilber/config/LocalProperties.java
+++ b/src/main/java/org/rappsilber/config/LocalProperties.java
@@ -132,7 +132,7 @@ public  class LocalProperties {
      */
     public static synchronized Object setProperty(String key, String value)  {
         String old = localProperties.getProperty(key);
-        if ((old == null && value != null) || old.contentEquals(value)) {
+        if ((old == null && value != null) || (old != null && old.contentEquals(value))) {
             Object ret = localProperties.setProperty(key, value);
             try {
                 localProperties.store(new FileOutputStream(userPropertiesFile), "XLink local properties file");

--- a/src/main/java/org/rappsilber/config/LocalProperties.java
+++ b/src/main/java/org/rappsilber/config/LocalProperties.java
@@ -132,7 +132,7 @@ public  class LocalProperties {
      */
     public static synchronized Object setProperty(String key, String value)  {
         String old = localProperties.getProperty(key);
-        if ((old == null && value != null) || (old != null && old.contentEquals(value))) {
+        if ((old == null && value != null) || (old != null && !old.contentEquals(value))) {
             Object ret = localProperties.setProperty(key, value);
             try {
                 localProperties.store(new FileOutputStream(userPropertiesFile), "XLink local properties file");

--- a/src/main/java/org/rappsilber/fdr/MZIdentXLFDR.java
+++ b/src/main/java/org/rappsilber/fdr/MZIdentXLFDR.java
@@ -16,11 +16,12 @@
 package org.rappsilber.fdr;
 
 import org.rappsilber.fdr.result.FDRResult;
-import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,12 +29,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.rappsilber.fdr.OfflineFDR;
 import org.rappsilber.fdr.entities.PSM;
 import org.rappsilber.fdr.entities.PeptidePair;
 import org.rappsilber.fdr.utils.StreamReplaceWriter;
 import uk.ac.ebi.jmzidml.MzIdentMLElement;
-import uk.ac.ebi.jmzidml.model.mzidml.AbstractParam;
 import uk.ac.ebi.jmzidml.model.mzidml.AnalysisCollection;
 import uk.ac.ebi.jmzidml.model.mzidml.AnalysisProtocolCollection;
 import uk.ac.ebi.jmzidml.model.mzidml.AnalysisSoftware;
@@ -49,19 +48,17 @@ import uk.ac.ebi.jmzidml.model.mzidml.Modification;
 import uk.ac.ebi.jmzidml.model.mzidml.Param;
 import uk.ac.ebi.jmzidml.model.mzidml.PeptideEvidence;
 import uk.ac.ebi.jmzidml.model.mzidml.PeptideEvidenceRef;
-import uk.ac.ebi.jmzidml.model.mzidml.PeptideHypothesis;
-import uk.ac.ebi.jmzidml.model.mzidml.ProteinAmbiguityGroup;
 import uk.ac.ebi.jmzidml.model.mzidml.ProteinDetectionHypothesis;
 import uk.ac.ebi.jmzidml.model.mzidml.ProteinDetectionList;
 import uk.ac.ebi.jmzidml.model.mzidml.Provider;
 import uk.ac.ebi.jmzidml.model.mzidml.SequenceCollection;
 import uk.ac.ebi.jmzidml.model.mzidml.SpectraData;
 import uk.ac.ebi.jmzidml.model.mzidml.SpectrumIdentificationItem;
-import uk.ac.ebi.jmzidml.model.mzidml.SpectrumIdentificationItemRef;
 import uk.ac.ebi.jmzidml.model.mzidml.SpectrumIdentificationList;
 import uk.ac.ebi.jmzidml.model.mzidml.SpectrumIdentificationResult;
 import uk.ac.ebi.jmzidml.model.mzidml.SubstitutionModification;
 import uk.ac.ebi.jmzidml.model.mzidml.UserParam;
+import uk.ac.ebi.jmzidml.model.utils.MzIdentMLVersion;
 import uk.ac.ebi.jmzidml.xml.io.MzIdentMLMarshaller;
 import uk.ac.ebi.jmzidml.xml.io.MzIdentMLUnmarshaller;
 
@@ -704,11 +701,11 @@ public class MZIdentXLFDR extends OfflineFDR {
             if (!outFile.endsWith(".mzid")) {
                 outFile = outFile + ".mzid";
             }
-            FileWriter fwriter = new FileWriter(outFile);
-            StreamReplaceWriter writer = new StreamReplaceWriter(fwriter, "xmlns=\"http://psidev.info/psi/pi/mzIdentML/1.1\"", "");
+            FileOutputStream fwriter = new FileOutputStream(outFile);
+            OutputStreamWriter writer = new OutputStreamWriter(fwriter, "UTF-8");
             
             MzIdentMLMarshaller marshaller;
-            marshaller = new MzIdentMLMarshaller();
+            marshaller = new MzIdentMLMarshaller(MzIdentMLVersion.Version_1_3);
     
             writer.write(marshaller.createXmlHeader() + "\n");
 

--- a/src/main/java/org/rappsilber/fdr/calculation/Boost.java
+++ b/src/main/java/org/rappsilber/fdr/calculation/Boost.java
@@ -81,7 +81,7 @@ public class Boost {
 
         try {
             int steps = settings.getBoostingSteps();
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             double maxDelta = 1;
             double maxPeptideCoverage = 1;
 

--- a/src/main/java/org/rappsilber/fdr/dataimport/Xi2Xi1Config.java
+++ b/src/main/java/org/rappsilber/fdr/dataimport/Xi2Xi1Config.java
@@ -17,11 +17,8 @@ package org.rappsilber.fdr.dataimport;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -30,7 +27,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.json.simple.parser.ParseException;
 import org.json.simple.parser.JSONParser;
-import org.rappsilber.utils.RArrayUtils;
 import org.rappsilber.utils.ms.Composition;
 import rappsilber.config.AbstractRunConfig;
 import rappsilber.config.ConfigurationParserException;
@@ -42,7 +38,6 @@ import rappsilber.ms.crosslinker.SymetricSingleAminoAcidRestrictedCrossLinker;
 import rappsilber.ms.sequence.AminoAcid;
 import rappsilber.ms.sequence.AminoModification;
 import rappsilber.ms.sequence.digest.AAConstrainedDigestion;
-import rappsilber.ms.sequence.ions.AIon;
 
 
 /**
@@ -51,8 +46,6 @@ import rappsilber.ms.sequence.ions.AIon;
  */
 public class Xi2Xi1Config extends AbstractRunConfig{
     HashMap<String, Double> default_xl_masses = new HashMap<>();
-    {
-    }
     HashMap<String, CrossLinker> default_xl_xi1 = new HashMap<>();
     HashMap<String, Xi2Crosslinker> default_xl_xi2 = new HashMap<>();
     public boolean isModX = true;
@@ -97,12 +90,19 @@ public class Xi2Xi1Config extends AbstractRunConfig{
     }
     
     
+    /**
+     * Java representation of the xiSEARCH2 crosslinker definition. 
+     * Only the here needed information are retained
+     */
     public class Xi2Crosslinker {
         public String name;
         public Double mass ;
         String[][] specificity = new String[2][];
         
-
+        /**
+         * initialise just with name and get the rest from default definitions.
+         * @param name Name of the crosslinker
+         */
         public Xi2Crosslinker(String name) {
             this.name = name;
             if (default_xl_masses.containsKey(name.toUpperCase())) {
@@ -112,17 +112,32 @@ public class Xi2Xi1Config extends AbstractRunConfig{
             }
         }
         
+        /**
+         * Initialise by name and mass.
+         * @param name Name of the crosslinker
+         * @param mass mass of the reacted crosslinker
+         */
         public Xi2Crosslinker(String name, double mass) {
             this.name = name;
             this.mass = mass;
         }
 
+        /**
+         * Initialise by name, mass, and specificity.
+         * @param name Name of the crosslinker
+         * @param mass mass of the reacted crosslinker
+         * @param specificity where can the crosslinker react
+         */
         public Xi2Crosslinker(String name, double mass, String[][] specificity) {
             this.name = name;
             this.mass = mass;
             this.specificity = specificity;
         }
 
+        /**
+         * initialise based on a json crosslinker defintion derived map
+         * @param m 
+         */
         public Xi2Crosslinker(Map m) {
             this.name = m.get("name").toString();
             this.mass = (Double) m.get("mass");
@@ -154,6 +169,12 @@ public class Xi2Xi1Config extends AbstractRunConfig{
             }
         }
         
+        /**
+         * Convert to a xiSEARCH1 crosslinker definition.
+         * @return
+         * @throws java.text.ParseException
+         * @throws ConfigurationParserException 
+         */
         public String toXi1Crosslinker() throws java.text.ParseException, ConfigurationParserException {
             StringBuilder sb = new StringBuilder("crosslinker:AsymetricSingleAminoAcidRestrictedCrossLinker:NAME:");
             sb.append(this.name);

--- a/src/main/java/org/rappsilber/fdr/entities/Protein.java
+++ b/src/main/java/org/rappsilber/fdr/entities/Protein.java
@@ -16,12 +16,14 @@
 package org.rappsilber.fdr.entities;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.rappsilber.fdr.utils.FDRGroupNames;
 import org.rappsilber.utils.DoubleArrayList;
+import java.util.regex.*;
 
 /**
  * Represents a single protein. 
@@ -53,8 +55,7 @@ public class Protein extends AbstractFDRElement<Protein> {//implements Comparabl
     public static String DECOY_PREFIX = null;
     String zero = ""+(char)0;
     private Pattern zerosplit = Pattern.compile(zero);
-    private Pattern spacesplit = Pattern.compile(" ");
-    
+    private Pattern spacesplit = Pattern.compile("^\\s*(\"[^\"]*\"|'[^']*'|\\([^)]*\\)|[^\\s]+)");
     
     
     private String fdrgroup = null;
@@ -132,7 +133,13 @@ public class Protein extends AbstractFDRElement<Protein> {//implements Comparabl
                 this.name = zerosplit.split(description)[1];
                 this.description = zerosplit.split(description)[0];
             } else {
-                this.name = spacesplit.split(description)[0];
+                // try parsing a name from description
+                Matcher m = spacesplit.matcher(description);
+                if (m.find()) {
+                    this.name = m.group(1);
+                } else {
+                    this.name = this.description;
+                }
             }
         }
         

--- a/src/main/java/org/rappsilber/fdr/entities/Protein.java
+++ b/src/main/java/org/rappsilber/fdr/entities/Protein.java
@@ -23,7 +23,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.rappsilber.fdr.utils.FDRGroupNames;
 import org.rappsilber.utils.DoubleArrayList;
-import java.util.regex.*;
 
 /**
  * Represents a single protein. 

--- a/src/main/java/org/rappsilber/fdr/utils/MZIdentMLExport.java
+++ b/src/main/java/org/rappsilber/fdr/utils/MZIdentMLExport.java
@@ -1114,7 +1114,6 @@ public class MZIdentMLExport {
         // look up stubs
         ArrayList<CvParam> stubs = new ArrayList();
         int ast = 0;
-        ArrayList<String> stubNames = new ArrayList<>();
         CvParam stubA = null;
         CvParam stubS = null;
         CvParam stubT = null;
@@ -1128,7 +1127,6 @@ public class MZIdentMLExport {
                 cvp.setCv(psiCV);
                 cvp.setName(crosslinkerStubName);
                 cvp.setValue(name +":" + mass + ":");
-                stubNames.add(name);
                 if (name.toLowerCase().contentEquals("a")) {
                     ast++;
                     stubA = cvp;
@@ -1153,8 +1151,8 @@ public class MZIdentMLExport {
         } else if (stubs.size() == 2) {
             String s0 = stubs.get(0).getValue();
             String s1 = stubs.get(1).getValue();
-            String n0 = s0.substring(0);
-            String n1 = s1.substring(0);
+            String n0 = s0.substring(0,1);
+            String n1 = s1.substring(0,1);
             stubs.get(0).setValue(s0+n1);
             stubs.get(1).setValue(s1+n0);
         }

--- a/src/main/java/org/rappsilber/fdr/utils/MZIdentMLExport.java
+++ b/src/main/java/org/rappsilber/fdr/utils/MZIdentMLExport.java
@@ -9,10 +9,13 @@ package org.rappsilber.fdr.utils;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.lang.reflect.Method;
 import java.text.ParseException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -20,7 +23,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Vector;
+import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.swing.BoxLayout;
@@ -102,6 +105,9 @@ import rappsilber.ms.sequence.AminoAcid;
 import rappsilber.ms.sequence.AminoModification;
 import rappsilber.ms.sequence.ions.AIon;
 import rappsilber.utils.Util;
+import uk.ac.ebi.jmzidml.model.mzidml.AnalysisData;
+import uk.ac.ebi.jmzidml.model.mzidml.DataCollection;
+import uk.ac.ebi.jmzidml.model.mzidml.MzIdentML;
 import uk.ac.ebi.jmzidml.model.mzidml.PeptideHypothesis;
 import uk.ac.ebi.jmzidml.model.mzidml.ProteinAmbiguityGroup;
 import uk.ac.ebi.jmzidml.model.mzidml.ProteinDetectionHypothesis;
@@ -175,7 +181,9 @@ public class MZIdentMLExport {
      */
     private static String crosslinkedAcceptorModAcc = "MS:1002510";
     private static String crosslinkedAcceptorModName = "cross-link acceptor";
-//    
+    // crosslinker stub    
+    private static String crosslinkerStubAcc= "MS:1003390";
+    private static String crosslinkerStubName = "crosslinker cleavage characteristics";
     // name to xi crosslinker lookup
     private HashMap<String,rappsilber.ms.crosslinker.CrossLinker> name2xiXL = new HashMap<>();
     //These are the main structures to be output by the main writing method
@@ -454,8 +462,10 @@ public class MZIdentMLExport {
             Logger.getLogger(MZIdentMLExport.class.getName()).log(Level.SEVERE, null, ex);
         }
         rappsilber.config.RunConfig conf = ((XiInFDR)fdr).getConfig();
+
         // Setup the mzid objects
         handleCVs();
+        ArrayList<CvParam> stubs = parseStubs(conf);
         
 
         HashMap<String, DBSequence> foundProts = new HashMap<String, DBSequence>();
@@ -476,7 +486,7 @@ public class MZIdentMLExport {
         handleAuditCollection(owner.first, owner.last, owner.email, owner.address, owner.org);
         handleProvider();                //Performed after auditcollection, since contact is needed for provider
 
-        boolean fragmentIsMono = handleAnalysisProtocolCollection(fdr, result);
+        boolean fragmentIsMono = handleAnalysisProtocolCollection(fdr, result, stubs);
         inputs = new Inputs();
 //        handleInputs(fdr, "", "", result.proteinGroupFDR.getInputCount(), "");
 //        handleAnalysisCollection("");
@@ -509,6 +519,8 @@ public class MZIdentMLExport {
         HashMap<String,CvParam> xlMass2DonorModParamByName = new HashMap<String, CvParam> (conf.getCrossLinker().size());
         
         for (rappsilber.ms.crosslinker.CrossLinker cl : conf.getCrossLinker()) {
+            if (cl.getName().trim().replaceAll("[- ]*", "").toLowerCase().contains("noncovalent"))
+                continue;
             double xlMass = cl.getCrossLinkedMass();
             CvParam XLDonorModParam = new CvParam();
             
@@ -521,9 +533,9 @@ public class MZIdentMLExport {
                     if (cl.canCrossLink(p,p2)) {
                         // querry xlmod
                         boolean[] term = new boolean[]{false,false};
-                        XLModEntry e = xlmod.guessModification(new XLModQuery(xlMass, cl.getName(), new String[] {aa.toString(),aa2.toString()}, term,term,term,term));
+                        XLModEntry e = xlmod.guessModification(new XLModQuery(xlMass, cl.getName(), new String[] {aa.toString(),aa2.toString()}, term,term,term,term, true));
                         if (e == null) {
-                            e = xlmod.guessModification(new XLModQuery(xlMass, new String[] {aa.toString(),aa2.toString()}, term,term,term,term));
+                            e = xlmod.guessModification(new XLModQuery(xlMass, new String[] {aa.toString(),aa2.toString()}, term,term,term,term, false));
                         }
 
                         if (e != null) {
@@ -713,7 +725,7 @@ public class MZIdentMLExport {
                         // the first peptide get the crosslinker as modification added
                         if (pi == 0 ) {
                             if (!psm.isLinear()) {
-                                if (!psm.getCrosslinker().replaceAll("[-\\s]","").contains("noncovalent")) {
+                                if (!psm.getCrosslinker().replaceAll("[-\\s]","").toLowerCase().contains("noncovalent")) {
                                     CvParam  XLDonorModParam =  xlMass2DonorModParam.get((int)(psmXLMass*1000));
                                     if (XLDonorModParam == null)
                                         XLDonorModParam =  xlMass2DonorModParamByName.get(xl_name);
@@ -724,6 +736,7 @@ public class MZIdentMLExport {
                                     xlModParam.setCv(psiCV);
                                     xlModParam.setValue(Integer.toString(xlModId));
                                     mod.getCvParam().add(xlModParam);
+                                    mod.getCvParam().addAll(stubs);
                                     mzidPep.getModification().add(mod);
                                 }
                             } else if (psm.isLoop()) {
@@ -746,10 +759,11 @@ public class MZIdentMLExport {
                                 xlModParam.setCv(psiCV);
                                 xlModParam.setValue(Integer.toString(xlModId));
                                 mod.getCvParam().add(xlModParam);
+                                mod.getCvParam().addAll(stubs);
                                 mzidPep.getModification().add(mod);
                             }
                         } else {
-                            if (!psm.getCrosslinker().replaceAll("[-\\s]","").contains("noncovalent")) {
+                            if (!psm.getCrosslinker().replaceAll("[-\\s]","").toLowerCase().contains("noncovalent")) {
                                 // the second peptide becomes a zero-mass modification added, that denote the linkage site on this peptide
                                 uk.ac.ebi.jmzidml.model.mzidml.Modification mod = getCrosslinkerReceptorModification(link, 0, fragmentIsMono);
                                 CvParam xlModParam = new CvParam();
@@ -803,7 +817,7 @@ public class MZIdentMLExport {
 
                     sii.setPeptide(mzidPep);
                     if (psmpeps.length>1) {
-                        if (!psm.getCrosslinker().replaceAll("[-\\s]","").contains("noncovalent")) {
+                        if (!psm.getCrosslinker().replaceAll("[-\\s]","").toLowerCase().contains("noncovalent")) {
                             CvParam xlModParam = new CvParam();
                             xlModParam.setAccession(crosslinkedSIIAcc);
                             xlModParam.setValue(Integer.toString(xlModId));
@@ -854,7 +868,8 @@ public class MZIdentMLExport {
                             foundProts.put(protKey, dbSeq);
                             dbSeq.setAccession(prot.getAccession());
                             dbSeq.setName(prot.isDecoy() ? "decoy" : prot.getName());
-                            dbSeq.getCvParam().add(makeCvParam("MS:1001088", "protein description", psiCV,prot.getDescription()));
+                            if (prot.getDescription() != null  && prot.getDescription().trim().length()>0)
+                                dbSeq.getCvParam().add(makeCvParam("MS:1001088", "protein description", psiCV,prot.getDescription()));
                             if (prot.getSize() >0)
                                 dbSeq.setLength(prot.getSize());
                             if (prot.getSequence() != null && !prot.getSequence().isEmpty())
@@ -1094,6 +1109,57 @@ public class MZIdentMLExport {
         }        
         
     }
+
+    private ArrayList<CvParam> parseStubs(RunConfig conf) {
+        // look up stubs
+        ArrayList<CvParam> stubs = new ArrayList();
+        int ast = 0;
+        ArrayList<String> stubNames = new ArrayList<>();
+        CvParam stubA = null;
+        CvParam stubS = null;
+        CvParam stubT = null;
+        for (rappsilber.ms.sequence.ions.CrossLinkedFragmentProducer cfp: conf.getCrossLinkedFragmentProducers()) {
+            if (cfp instanceof rappsilber.ms.sequence.ions.loss.CleavableCrossLinkerPeptide) {
+                rappsilber.ms.sequence.ions.loss.CleavableCrossLinkerPeptide p = (rappsilber.ms.sequence.ions.loss.CleavableCrossLinkerPeptide) cfp;
+                String name = p.getName().substring(0,1);
+                Double mass = p.getDeltamass();
+                CvParam cvp = new CvParam();
+                cvp.setAccession(crosslinkerStubAcc);
+                cvp.setCv(psiCV);
+                cvp.setName(crosslinkerStubName);
+                cvp.setValue(name +":" + mass + ":");
+                stubNames.add(name);
+                if (name.toLowerCase().contentEquals("a")) {
+                    ast++;
+                    stubA = cvp;
+                } else if (name.toLowerCase().contentEquals("s")) {
+                    ast++;
+                    stubS = cvp;
+                } else if  (name.toLowerCase().contentEquals("t")) {
+                    ast++;
+                    stubT = cvp;
+                }
+                stubs.add(cvp);
+            }
+        }
+        // make some eductated guesses for stub pairing
+        if (ast == 3) {
+            char aName =  stubA.getValue().charAt(0);
+            char sName =  stubS.getValue().charAt(0);
+            char tName =  stubT.getValue().charAt(0);
+            stubA.setValue(stubA.getValue()+sName + tName);
+            stubT.setValue(stubT.getValue()+aName);
+            stubS.setValue(stubS.getValue()+aName);
+        } else if (stubs.size() == 2) {
+            String s0 = stubs.get(0).getValue();
+            String s1 = stubs.get(1).getValue();
+            String n0 = s0.substring(0);
+            String n1 = s1.substring(0);
+            stubs.get(0).setValue(s0+n1);
+            stubs.get(1).setValue(s1+n0);
+        }
+        return stubs;
+    }
     
 
     /**
@@ -1246,9 +1312,9 @@ public class MZIdentMLExport {
         residueList.add("" + reportedAminoAcid);
 
         boolean[] term =new boolean[]{false};
-        XLModEntry e = xlmod.guessModificationCached(new XLModQuery(mass, reportedMod.SequenceID.substring(1) , new String[]{reportedMod.BaseAminoAcid.SequenceID}, term, term, term, term));
+        XLModEntry e = xlmod.guessModificationCached(new XLModQuery(mass, reportedMod.SequenceID.substring(1) , new String[]{reportedMod.BaseAminoAcid.SequenceID}, term, term, term, term, false));
         if  (e == null) {
-            e = xlmod.guessModificationCached(new XLModQuery(mass, new String[]{reportedMod.BaseAminoAcid.SequenceID}, term, term, term, term));
+            e = xlmod.guessModificationCached(new XLModQuery(mass, new String[]{reportedMod.BaseAminoAcid.SequenceID}, term, term, term, term, false));
         }
 
         if  (e == null) {
@@ -1911,7 +1977,7 @@ public class MZIdentMLExport {
      *
      *
      */
-    public boolean handleAnalysisProtocolCollection(OfflineFDR fdr, FDRResult result) {//InputParams inputParams){
+    public boolean handleAnalysisProtocolCollection(OfflineFDR fdr, FDRResult result, ArrayList<CvParam> stubs) {//InputParams inputParams){
 
         //boolean (parentIsMono, boolean fragmentIsMono, SearchModification[] searchMods, String enzymeName, double parTolPlus, double parTolMinus, double fragTolPlus, double fragTolMinus);
         if (analysisProtocolCollection == null) {
@@ -1993,10 +2059,10 @@ public class MZIdentMLExport {
 
             //residue, potential modification mass
             ArrayList<AminoModification> fixedmods = conf.getFixedModifications();
-
+            
             for (rappsilber.ms.crosslinker.CrossLinker xl : conf.getCrossLinker()) {
                 if (!(xl instanceof NonCovalentBound)){
-                    List<SearchModification> searchMod = translateToSearchModification(xl, ((XiInFDR)fdr).getConfig());
+                    List<SearchModification> searchMod = translateToSearchModification(xl, stubs, ((XiInFDR)fdr).getConfig());
                     searchModList.addAll(searchMod);
                 }
             }
@@ -2241,7 +2307,7 @@ public class MZIdentMLExport {
             rappsilber.config.RunConfig conf, 
             boolean pepNTerm, boolean pepCTerm,
             boolean protNTerm, boolean protCTerm) {
-        Vector<String> residues = new Vector<String>();
+        ArrayList<String> residues = new ArrayList<String>();
         double monoMass = reportedMod.mass - base.mass;
 
         residues.addAll(modResidues);
@@ -2253,18 +2319,18 @@ public class MZIdentMLExport {
         if (unimod == null && base != AminoAcid.X) {
             String modname = reportedMod.SequenceID.replaceAll("[A-Z]", "");
             boolean[] term =new boolean[]{false};
-            XLModEntry e = xlmod.guessModificationCached(new XLModQuery(monoMass, modname, new String[]{base.SequenceID}, term, term, term, term));
+            XLModEntry e = xlmod.guessModificationCached(new XLModQuery(monoMass, modname, new String[]{base.SequenceID}, term, term, term, term, false));
             
             if (e==null) {
                 // could be a cross-linker specific modification
                 for (rappsilber.ms.crosslinker.CrossLinker cl :conf.getCrossLinker()) {
-                    e = xlmod.guessModificationCached(new XLModQuery(monoMass, cl.getName(), new String[]{base.SequenceID}, term, term, term, term));                
+                    e = xlmod.guessModificationCached(new XLModQuery(monoMass, cl.getName(), new String[]{base.SequenceID}, term, term, term, term, false));                
                 }
             }
             // nothing found wih name so try without name
             if (e==null) {
                 
-                e = xlmod.guessModificationCached(new XLModQuery(monoMass, new String[]{base.SequenceID}, term, term, term, term));
+                e = xlmod.guessModificationCached(new XLModQuery(monoMass, new String[]{base.SequenceID}, term, term, term, term, false));
             }
             if  (e == null) {
                 searchMod.getCvParam().add(makeCvParam("MS:1001460", "unknown modification", psiCV));
@@ -2302,9 +2368,8 @@ public class MZIdentMLExport {
      * @param isFixedMod
      * @return
      */
-    private List<SearchModification> translateToSearchModification(rappsilber.ms.crosslinker.CrossLinker crosslinker, rappsilber.config.RunConfig conf) {
+    private List<SearchModification> translateToSearchModification(rappsilber.ms.crosslinker.CrossLinker crosslinker, List<CvParam> stubs, rappsilber.config.RunConfig conf) {
         ArrayList<SearchModification> ret = new ArrayList<SearchModification>();
-        Vector<String> residues = new Vector<String>();
         //String[] temp = reportedMod.split("@");
         double monoMass = massNormalise(crosslinker.getCrossLinkedMass());
 
@@ -2333,11 +2398,11 @@ public class MZIdentMLExport {
             if (xl.getAASpecificity(1).size() >0) {
                 specificity[1] = xl.getAASpecificity(1).iterator().next().SequenceID;
             }
-            e = xlmod.guessModificationCached(new XLModQuery(monoMass, crosslinker.getName(), specificity, term, term, term, term));
+            e = xlmod.guessModificationCached(new XLModQuery(monoMass, crosslinker.getName(), specificity, term, term, term, term, true));
 
             // nothing found wih name so try without name
             if (e==null) {
-                e = xlmod.guessModificationCached(new XLModQuery(monoMass, specificity, term, term, term, term));
+                e = xlmod.guessModificationCached(new XLModQuery(monoMass, specificity, term, term, term, term, false));
             }
         }
         if  (e == null) {
@@ -2346,6 +2411,7 @@ public class MZIdentMLExport {
             modParam = makeCvParam(e.getId(), e.getName(), xlmodCV);
         }
         searchMod.getCvParam().add(modParam);
+        searchMod.getCvParam().addAll(stubs);
         
         if (crosslinker instanceof rappsilber.ms.crosslinker.AminoAcidRestrictedCrossLinker) {
             HashSet<String> modsRes = new HashSet<>();
@@ -2406,10 +2472,11 @@ public class MZIdentMLExport {
             sr.getCvParam().add(makeCvParam("MS:1002058", "modification specificity protein C-term", psiCV));
             searchModCTerm.getSpecificityRules().add(sr);
             searchModCTerm.getCvParam().add(makeCvParam(crosslinkedDonorModAcc, crosslinkedDonorModName, psiCV, ""+countCrossLinker));
+            searchModCTerm.getCvParam().addAll(stubs);
             ret.add(searchModCTerm);
             SearchModification searchModCTermAcceptor = new SearchModification();
             searchModCTermAcceptor.setFixedMod(true);
-            searchModCTermAcceptor.setMassDelta((float) monoMass);
+            searchModCTermAcceptor.setMassDelta((float) 0);
             searchModCTermAcceptor.getCvParam().add(modParam);
             searchModCTermAcceptor.getResidues().add(".");
             searchModCTermAcceptor.getSpecificityRules().add(sr);
@@ -2427,10 +2494,11 @@ public class MZIdentMLExport {
             sr.getCvParam().add(makeCvParam("MS:1002057", "modification specificity protein N-term", psiCV));
             searchModNTerm.getSpecificityRules().add(sr);
             searchModNTerm.getCvParam().add(makeCvParam(crosslinkedDonorModAcc, crosslinkedDonorModName, psiCV, ""+countCrossLinker));
+            searchModNTerm.getCvParam().addAll(stubs);
             ret.add(searchModNTerm);
             SearchModification searchModNTermAcceptor = new SearchModification();
             searchModNTermAcceptor.setFixedMod(true);
-            searchModNTermAcceptor.setMassDelta((float) monoMass);
+            searchModNTermAcceptor.setMassDelta((float) 0);
             searchModNTermAcceptor.getCvParam().add(modParam);
             searchModNTermAcceptor.getResidues().add(".");
             searchModNTermAcceptor.getSpecificityRules().add(sr);
@@ -2509,70 +2577,32 @@ public class MZIdentMLExport {
     public void writeMzidFile(String outputfile) {
             
         try {
-            FileWriter fwriter = new FileWriter(outputfile);
-            MzIdentMLMarshaller m = new MzIdentMLMarshaller(MzIdentMLVersion.Version_1_2);
+            FileOutputStream fwriter = new FileOutputStream(outputfile);
+            OutputStreamWriter writer = new OutputStreamWriter(fwriter, "UTF-8");
+            MzIdentMLMarshaller m = new MzIdentMLMarshaller(MzIdentMLVersion.Version_1_3);
 
-            StreamReplaceWriter writer = 
-                    new StreamReplaceWriter(fwriter, 
-                            new String[]{"/mzIdentML/1.2",
-                            "<MzIdentML id=\"12345\" version=\"1.2.0\"",
-                            "mzIdentML1.2.0.xsd"}, 
-                            new String[]{"/mzIdentML/1.3",
-                            "<MzIdentML id=\"12345\" version=\"1.3.0\"",
-                            "mzIdentML1.3.0.xsd"});
-
-
-            writer.write(m.createXmlHeader());
-            writer.write("\n");
-
-            // I replaced all 1.1 with 1.2 in the start tag - I am not sure if really all need to be replaced
-            writer.write(m.createMzIdentMLStartTag("12345") + "\n");
-
-            writer.setForwardOnly(true);
-
-//            // XML header
-//            writer.write(m.createXmlHeader() + "\n");
-//
-//
-//            // mzIdentML start tag
-//
-//            writer.write(m.createMzIdentMLStartTag("12345") + "\n");
-
-
-
-            m.marshal(cvList, writer);
-            writer.write("\n");
-
-            m.marshal(analysisSoftwareList, writer);
-            writer.write("\n");
-
-
-            m.marshal(provider, writer);
-            writer.write("\n");
-
-
-            m.marshal(auditCollection, writer);
-            writer.write("\n");
-
+            MzIdentML mzid = new MzIdentML();
+            mzid.setId(UUID.randomUUID().toString());
+            
+            mzid.setVersion("1.3.0");
+            mzid.setCvList(cvList);
+            mzid.setAnalysisSoftwareList(analysisSoftwareList);
+            mzid.setProvider(provider);
+            mzid.setAuditCollection(auditCollection);
+            mzid.setSequenceCollection(sequenceCollection);
+            mzid.setAnalysisCollection(analysisCollection);
+            mzid.setAnalysisProtocolCollection(analysisProtocolCollection);
+            
 
             //m.marshal(analysisSampleCollection, writer);     //TODO - complete this part
             //writer.write("\n");
+            DataCollection dc = new DataCollection();
+            dc.setInputs(inputs);
+            AnalysisData ad = new AnalysisData();
+            dc.setAnalysisData(ad);
+            mzid.setDataCollection(dc);
 
-
-            m.marshal(sequenceCollection, writer);
-            writer.write("\n");
-
-
-
-            m.marshal(analysisCollection, writer);
-            writer.write("\n");
-
-
-            m.marshal(analysisProtocolCollection, writer);
-            writer.write("\n");
-
-
-            writer.write(m.createDataCollectionStartTag() + "\n");
+            /*writer.write(m.createDataCollectionStartTag() + "\n");
             m.marshal(inputs, writer);
             writer.write("\n");
 
@@ -2582,38 +2612,29 @@ public class MZIdentMLExport {
             //writer.write("\n");
 
             writer.write(m.createAnalysisDataStartTag() + "\n");
-
+            */
 
 
             for (HashMap<String,SpectrumIdentificationList> run2sil : siList.values()) {
                 for (SpectrumIdentificationList sil : run2sil.values()) {
-                    m.marshal(sil, writer);
-                    writer.write("\n");
+                    ad.getSpectrumIdentificationList().add(sil);
                 }
             }
 
 
-            // writer.write(m.createSpectrumIdentificationListClosingTag() + "\n");
-//
-//            writer.write(m.createProteinDetectionListStartTag("PDL_1", null) + "\n");
             
             proteinDetectionList.setId("PDL_1");
             proteinDetectionList.getCvParam().add(makeCvParam("MS:1002404", "count of identified proteins",psiCV,""+ proteinDetectionList.getProteinAmbiguityGroup().size()));
-            m.marshal(proteinDetectionList, writer);
+            ad.setProteinDetectionList(proteinDetectionList);
 
 //            writer.write(m.createProteinDetectionListClosingTag() + "\n");
 
-            writer.write(m.createAnalysisDataClosingTag() + "\n");
+            // creat an ID by milliseconds
+            String id = "xiFDR" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS"));
+            // make it "unique" by adding 4 digits of randomness
+            id += "_" + Math.round(Math.random()*10000);
 
-            writer.write(m.createDataCollectionClosingTag() + "\n");
-
-            //BibliographicReference ref = unmarshaller.unmarshal(MzIdentMLElement.BibliographicReference.getXpath());
-            // m.marshal(ref, writer);
-            // writer.write("\n");
-
-
-
-            writer.write(m.createMzIdentMLClosingTag());
+            m.marshallRoot(mzid, writer, "UTF-8", id, MzIdentMLVersion.Version_1_3);
 
             writer.close();
 

--- a/src/main/java/org/rappsilber/fdr/utils/StreamReplaceWriter.java
+++ b/src/main/java/org/rappsilber/fdr/utils/StreamReplaceWriter.java
@@ -30,10 +30,7 @@ import java.io.Writer;
  * 
  */
 public class StreamReplaceWriter extends OutputStreamWriter{
-    /**
-     * The actual writer that where the data are forwarded to.
-     */
-    //private Writer innerWriter;
+    
     /**
      * the search-term
      */

--- a/src/main/java/org/rappsilber/fdr/utils/StreamReplaceWriter.java
+++ b/src/main/java/org/rappsilber/fdr/utils/StreamReplaceWriter.java
@@ -16,6 +16,9 @@
 package org.rappsilber.fdr.utils;
 
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 
 /**
@@ -26,11 +29,11 @@ import java.io.Writer;
  * @author lfischer@staffmail.ed.ac.uk
  * 
  */
-public class StreamReplaceWriter extends Writer{
+public class StreamReplaceWriter extends OutputStreamWriter{
     /**
      * The actual writer that where the data are forwarded to.
      */
-    private Writer innerWriter;
+    //private Writer innerWriter;
     /**
      * the search-term
      */
@@ -47,6 +50,7 @@ public class StreamReplaceWriter extends Writer{
     private int maxLength = 0;
     private boolean forwardOnly = false;
 
+    
     /**
      * 
      * @param innerWriter where are the - possibly modified - data to be written 
@@ -54,15 +58,19 @@ public class StreamReplaceWriter extends Writer{
      * @param search term to be searched
      * @param replace what replaces search
      */
-    public StreamReplaceWriter(Writer innerWriter, String search, String replace) {
-        this.innerWriter = innerWriter;
+    public StreamReplaceWriter(OutputStream innerWriter, String search, String replace,  String charsetName) throws UnsupportedEncodingException {
+        super(innerWriter, charsetName);
         this.search = new String[]{search};
         this.replace = new String[]{replace};
         maxLength = search.length();
     }
 
-    public StreamReplaceWriter(Writer innerWriter, String[] search, String[] replace) {
-        this.innerWriter = innerWriter;
+    public StreamReplaceWriter(OutputStream innerWriter, String search, String replace) throws UnsupportedEncodingException {
+        this(innerWriter, search, replace, "UTF-8");
+    }
+    
+    public StreamReplaceWriter(OutputStream innerWriter, String[] search, String[] replace, String charsetName) throws UnsupportedEncodingException {
+        super(innerWriter, charsetName);
         this.search = search;
         this.replace = replace;
         for (String s : search){
@@ -70,11 +78,16 @@ public class StreamReplaceWriter extends Writer{
                 maxLength = s.length();
         }
     }    
+    public StreamReplaceWriter(OutputStream innerWriter, String[] search, String[] replace) throws UnsupportedEncodingException {
+        this(innerWriter, search, replace, "UTF-8");
+    }
+
+    
     @Override
     public void write(char[] cbuf, int off, int len) throws IOException {
         
         if (isForwardOnly()) {
-            innerWriter.write(cbuf, off, len);
+            super.write(cbuf, off, len);
             return;
         }
         
@@ -100,7 +113,7 @@ public class StreamReplaceWriter extends Writer{
         if (writeOut >0) {
             String wos = sb.substring(0,writeOut);
             sb.delete(0, writeOut);
-            innerWriter.write(wos);
+            super.write(wos);
         }
         
         
@@ -115,14 +128,15 @@ public class StreamReplaceWriter extends Writer{
      */
     @Override
     public void flush() throws IOException {
-        innerWriter.flush();
+        super.write(sb.toString().toCharArray(),0, sb.length());
+        sb.setLength(0);
+        super.flush();
     }
 
     @Override
     public void close() throws IOException {
-        innerWriter.write(sb.toString());
-        sb.setLength(0);
-        innerWriter.close();
+        this.flush();
+        super.close();
     }
 
     /**
@@ -138,8 +152,7 @@ public class StreamReplaceWriter extends Writer{
     public void setForwardOnly(boolean forwardOnly) throws IOException {
         if (forwardOnly) {
             // flush out buffer
-            innerWriter.write(sb.toString());
-            sb.setLength(0);
+            this.flush();
         }
         this.forwardOnly = forwardOnly;
     }

--- a/src/main/resources/xifdrproject.properties
+++ b/src/main/resources/xifdrproject.properties
@@ -1,6 +1,14 @@
 xifdr.version=${project.version}
 xifdr.artifactId=${project.artifactId}
 xifdr.changelog=\
+2.3.8\n\
+* Write out crosslinker stub information to mzIdentML\n\
+* updated to XLMOD java library 1.1 to reduce "unknown modifications"\n\
+* BugFix: mzIdentML 1.3 empty protein descriptions no longer written out\n\
+* BugFix: mzIdentML 1.3 export still had some mzIdentML 1.2 namespace attributes\n\
+   * currently using a modified version of jmzIdentML (pull request pending)\n\
+   * allow matching to crosslinker without mass definition (e.g. DSSO)\n\
+* BugFix: mzIdentML export for non-covalent peptide pairs\n\
 2.3.7\n\
 * BugFix: xiview csv file can miss data\n\
 2.3.6\n\


### PR DESCRIPTION
* Write out crosslinker stub information to mzIdentML
* updated to XLMOD java library 1.1 to reduce "unknown modifications"
* BugFix: mzIdentML 1.3 empty protein descriptions no longer written out
* BugFix: mzIdentML 1.3 export still had some mzIdentML 1.2 namespace attributes
   * currently using a modified version of jmzIdentML (pull request pending)
   * allow matching to crosslinker without mass definition (e.g. DSSO)
* BugFix: mzIdentML export for non-covalent peptide pairs
